### PR TITLE
feat: add api controllers

### DIFF
--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { OrdersService } from '@/orders/orders.service';
+
+@Controller('analytics')
+export class AnalyticsController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Get()
+  findAll() {
+    return this.ordersService.getAllOrders();
+  }
+}

--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AnalyticsController } from './analytics.controller';
+import { OrdersModule } from '@/orders/orders.module';
+
+@Module({
+  imports: [OrdersModule],
+  controllers: [AnalyticsController]
+})
+export class AnalyticsModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,8 +1,3 @@
-/**
- * @file app.module.ts
- * @description Главный модуль приложения, который объединяет все остальные модули.
- * @author @KorzikAlex
- */
 import { resolve } from 'node:path';
 
 import { Module } from '@nestjs/common';
@@ -10,11 +5,13 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { HealthModule } from './health/health.module';
+import { OrdersModule } from './orders/orders.module';
+import { WorkersModule } from './workers/workers.module';
+import { AuthModule } from './auth/auth.module';
+import { AnalyticsModule } from './analytics/analytics.module';
+import { ImportModule } from './import/import.module';
+import { ExportModule } from './export/export.module';
 
-/**
- * @class AppModule
- * @description Главный модуль приложения, который объединяет все остальные модули.
- */
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -42,6 +39,12 @@ import { HealthModule } from './health/health.module';
       },
     }),
     HealthModule,
+    OrdersModule,
+    WorkersModule,
+    AuthModule,
+    AnalyticsModule,
+    ImportModule,
+    ExportModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,20 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+import { SignInDto } from './dto/sign-in.dto';
+import { SignUpDto } from './dto/sign-up.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('login')
+  signIn(@Body() signInDto: SignInDto) {
+    return this.authService.signIn(signInDto.email, signInDto.password);
+  }
+
+  @Post('signup')
+  signUp(@Body() signUpDto: SignUpDto) {
+    return this.authService.signUp(signUpDto);
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+
+@Module({
+  providers: [AuthService],
+  controllers: [AuthController]
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+
+import { SignUpDto } from './dto/sign-up.dto';
+
+@Injectable()
+export class AuthService {
+  async signIn(email: string, password: string) {}
+  async signUp(signUpDto: SignUpDto) {}
+}

--- a/backend/src/auth/dto/sign-in.dto.ts
+++ b/backend/src/auth/dto/sign-in.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class SignInDto {
+  @IsNotEmpty()
+  @IsString()
+  email: string;
+
+  @IsNotEmpty()
+  @IsString()
+  password: string;
+}

--- a/backend/src/auth/dto/sign-up.dto.ts
+++ b/backend/src/auth/dto/sign-up.dto.ts
@@ -1,0 +1,3 @@
+export class SignUpDto {
+  
+}

--- a/backend/src/export/dto/export-database.dto.ts
+++ b/backend/src/export/dto/export-database.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsString } from "class-validator";
+
+export class ExportDatabaseDto {
+  @IsOptional()
+  @IsString()
+  users?: string;
+
+  @IsOptional()
+  @IsString()
+  orders?: string;
+
+  @IsOptional()
+  @IsString()
+  format?: string;
+}

--- a/backend/src/export/export.controller.ts
+++ b/backend/src/export/export.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ExportService } from './export.service';
+import { ExportDatabaseDto } from './dto/export-database.dto';
+
+@Controller('export')
+export class ExportController {
+  constructor(private readonly exportService: ExportService) {}
+
+  @Get()
+  exportDatabase(@Query() exportDatabaseDto: ExportDatabaseDto) {
+    return this.exportService.exportDatabase(exportDatabaseDto);
+  }
+}

--- a/backend/src/export/export.module.ts
+++ b/backend/src/export/export.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ExportService } from './export.service';
+import { ExportController } from './export.controller';
+
+@Module({
+  providers: [ExportService],
+  controllers: [ExportController]
+})
+export class ExportModule {}

--- a/backend/src/export/export.service.ts
+++ b/backend/src/export/export.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+import { ExportDatabaseDto } from './dto/export-database.dto';
+
+@Injectable()
+export class ExportService {
+  async exportDatabase(exportDatabaseDto: ExportDatabaseDto) {}
+}

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,10 +1,3 @@
-/**
- * @file health.controller.ts
- * @description Контроллер для проверки состояния здоровья приложения.
- * Использует NestJS Terminus для выполнения проверок здоровья,
- * таких как проверка доступности внешних сервисов и баз данных.
- * @author @KorzikAlex
- */
 import { Controller, Get } from '@nestjs/common';
 import {
   HealthCheck,
@@ -13,33 +6,14 @@ import {
   MongooseHealthIndicator,
 } from '@nestjs/terminus';
 
-/**
- * @class HealthController
- * @description Контроллер для проверки состояния здоровья приложения.
- * Предоставляет эндпоинт /health, который возвращает статус здоровья приложения.
- * Включает проверки доступности внешних сервисов и баз данных.
- */
 @Controller('health')
 export class HealthController {
-  /**
-   * @constructor Создает экземпляр HealthController.
-   * @description Инициализирует сервисы для проверки здоровья,
-   * такие как HealthCheckService, HttpHealthIndicator и MongooseHealthIndicator.
-   * @param health Сервис для выполнения проверок здоровья.
-   * @param http Сервис для проверки доступности внешних HTTP сервисов.
-   * @param mongoose Сервис для проверки доступности MongoDB баз данных.
-   */
   constructor(
     private health: HealthCheckService,
     private http: HttpHealthIndicator,
     private mongoose: MongooseHealthIndicator,
   ) {}
 
-  /**
-   * @method check
-   * @returns Результат проверок здоровья приложения,
-   * включая статус доступности внешних сервисов и баз данных.
-   */
   @Get()
   @HealthCheck()
   check() {

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -1,20 +1,9 @@
-/**
- * @file health.module.ts
- * @description Модуль для проверки состояния здоровья приложения.
- * Использует NestJS Terminus для организации проверок здоровья,
- * таких как проверка доступности внешних сервисов и баз данных.
- * @author @KorzikAlex
- */
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 
 import { HealthController } from './health.controller';
 
-/**
- * @class HealthModule
- * @description Модуль для проверки состояния здоровья приложения.
- */
 @Module({
   imports: [TerminusModule, HttpModule],
   controllers: [HealthController],

--- a/backend/src/import/dto/import-database.dto.ts
+++ b/backend/src/import/dto/import-database.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsString } from "class-validator";
+
+export class ImportDatabaseDto {
+  @IsOptional()
+  @IsString()
+  users?: string;
+
+  @IsOptional()
+  @IsString()
+  orders?: string;
+
+  @IsOptional()
+  @IsString()
+  format?: string;
+}

--- a/backend/src/import/import.controller.ts
+++ b/backend/src/import/import.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ImportService } from './import.service';
+import { ImportDatabaseDto } from './dto/import-database.dto';
+
+@Controller('export')
+export class ImportController {
+  constructor(private readonly importService: ImportService) {}
+
+  @Get()
+  exportDatabase(@Query() importDatabaseDto: ImportDatabaseDto) {
+    return this.importService.importDatabase(importDatabaseDto);
+  }
+}

--- a/backend/src/import/import.module.ts
+++ b/backend/src/import/import.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ImportService } from './import.service';
+import { ImportController } from './import.controller';
+
+@Module({
+  providers: [ImportService],
+  controllers: [ImportController]
+})
+export class ImportModule {}

--- a/backend/src/import/import.service.ts
+++ b/backend/src/import/import.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+import { ImportDatabaseDto } from './dto/import-database.dto';
+
+@Injectable()
+export class ImportService {
+  async importDatabase(importDatabaseDto: ImportDatabaseDto) {}
+}

--- a/backend/src/orders/dto/create-order.dto.ts
+++ b/backend/src/orders/dto/create-order.dto.ts
@@ -1,0 +1,3 @@
+export class CreateOrderDto {
+  
+}

--- a/backend/src/orders/dto/update-order.dto.ts
+++ b/backend/src/orders/dto/update-order.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateOrderDto {
+  
+}

--- a/backend/src/orders/orders.controller.ts
+++ b/backend/src/orders/orders.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+
+@Controller('orders')
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Get()
+  findAll() {
+    return this.ordersService.getAllOrders();
+  }
+
+  @Get(':id') 
+  findOne(@Param('id') id: string){
+    return this.ordersService.getOrderById(id);
+  }
+
+  @Post()
+  async create(@Body() createOrderDto: CreateOrderDto) {
+    return this.ordersService.createOrder(createOrderDto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() updateOrderDto: UpdateOrderDto) {
+    return this.ordersService.updateOrder(id, updateOrderDto);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.ordersService.deleteOrder(id);
+  }
+}

--- a/backend/src/orders/orders.module.ts
+++ b/backend/src/orders/orders.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { OrdersController } from './orders.controller';
+import { OrdersService } from './orders.service';
+
+@Module({
+  controllers: [OrdersController],
+  providers: [OrdersService],
+  exports: [OrdersService],
+})
+export class OrdersModule {}

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+
+import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+
+@Injectable()
+export class OrdersService {
+  async getAllOrders() {}
+  async getOrderById(id: string) {}
+  async createOrder(dto: CreateOrderDto) {}
+  async updateOrder(id: string, dto: UpdateOrderDto) {}
+  async deleteOrder(id: string) {}
+}

--- a/backend/src/workers/dto/create-worker.dto.ts
+++ b/backend/src/workers/dto/create-worker.dto.ts
@@ -1,0 +1,3 @@
+export class CreateWorkerDto {
+
+}

--- a/backend/src/workers/dto/update-worker.dto.ts
+++ b/backend/src/workers/dto/update-worker.dto.ts
@@ -1,0 +1,3 @@
+export class UpdateWorkerDto {
+  
+}

--- a/backend/src/workers/workers.controller.ts
+++ b/backend/src/workers/workers.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { WorkersService } from './workers.service';
+import { CreateWorkerDto } from './dto/create-worker.dto';
+import { UpdateWorkerDto } from './dto/update-worker.dto';
+
+@Controller('workers')
+export class WorkersController {
+  constructor(private readonly workersService: WorkersService) {}
+
+  @Get()
+  findAll() {
+    return this.workersService.getAllWorkers();
+  }
+
+  @Get(':id') 
+  findOne(@Param('id') id: string){
+    return this.workersService.getWorkerById(id);
+  }
+
+  @Post()
+  async create(@Body() createWorkerDto: CreateWorkerDto) {
+    return this.workersService.createWorker(createWorkerDto);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() updateWorkerDto: UpdateWorkerDto) {
+    return this.workersService.updateWorker(id, updateWorkerDto);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.workersService.deleteWorker(id);
+  }
+}

--- a/backend/src/workers/workers.module.ts
+++ b/backend/src/workers/workers.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { WorkersController } from './workers.controller';
+import { WorkersService } from './workers.service';
+
+@Module({
+  controllers: [WorkersController],
+  providers: [WorkersService]
+})
+export class WorkersModule {}

--- a/backend/src/workers/workers.service.ts
+++ b/backend/src/workers/workers.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+
+import { CreateWorkerDto } from './dto/create-worker.dto';
+import { UpdateWorkerDto } from './dto/update-worker.dto';
+
+@Injectable()
+export class WorkersService {
+  async getAllWorkers() {}
+  async getWorkerById(id: string) {}
+  async createWorker(dto: CreateWorkerDto) {}
+  async updateWorker(id: string, dto: UpdateWorkerDto) {}
+  async deleteWorker(id: string) {}
+}


### PR DESCRIPTION
Реализованы контроллеры для эндпоинтов без наполнения сервисов:
- `POST /login`
- `POST /signup`
- `GET, POST /orders`
- `GET, PATCH (PUT), DELETE /orders/{id}`
- `GET, POST /workers`
- `GET, PATCH (PUT), DELETE /workers/{id}`
- `GET /analytics`
- `GET /export` 
- `POST /import`